### PR TITLE
Add support for lambdas with dashes and underscores in the name.

### DIFF
--- a/__tests__/add-log-subscriptions.js
+++ b/__tests__/add-log-subscriptions.js
@@ -18,13 +18,13 @@ test('does nothing when there are no functions', t => {
 });
 
 test('adds subscriptions for enabled functions', t => {
-  const normalizeName = sinon.stub()
+  const getNormalizedFunctionName = sinon.stub()
     .onCall(0).returns('A')
     .onCall(1).returns('B');
 
   const provider = {
     naming: {
-      normalizeName
+      getNormalizedFunctionName
     }
   };
   const serverless = {
@@ -58,11 +58,11 @@ test('adds subscriptions for enabled functions', t => {
 });
 
 test('configures the subscription filter correctly', t => {
-  const normalizeName = sinon.stub().returns('A');
+  const getNormalizedFunctionName = sinon.stub().returns('A');
 
   const provider = {
     naming: {
-      normalizeName
+      getNormalizedFunctionName
     }
   };
   const serverless = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-plugin-log-subscription",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Attach a CloudWatch LogSubscription to your functions' logs",
   "main": "serverless-plugin-log-subscription.js",
   "scripts": {

--- a/serverless-plugin-log-subscription.js
+++ b/serverless-plugin-log-subscription.js
@@ -27,7 +27,7 @@ module.exports = class LogSubscriptionsPlugin {
         const config = this.getConfig(custom.logSubscription, fn);
 
         if (config.enabled) {
-          const key = `${aws.naming.normalizeName(functionName)}SubscriptionFilter`;
+          const key = `${aws.naming.getNormalizedFunctionName(functionName)}SubscriptionFilter`;
 
           template.Resources[key] = {
             Type: "AWS::Logs::SubscriptionFilter",


### PR DESCRIPTION
Serverless function reference: https://github.com/serverless/serverless/blob/8b0981986600ec5f4e61a7c7e890f89a7fb24de6/lib/plugins/aws/lib/naming.js#L117