### PR TITLE
Add support for adding a RoleArn for logs putting to Kinesis streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Configuration happens both 'globally' (via custom.logSubscription) and also at t
 
 `destinationArn` (required) - the arn of the CloudWatch Destination (you create this resource yourself)
 
+`roleArn` (optional) - the arn of the IAM role granting logs permission to put to Destination (you create this resource yourself)
+
 `filterPattern` (optional) if specified, it will only forward logs matching this pattern. You can do simple token matching, or JSON matching (e.g. `{ $.level >= 30 }` to match a bunyan level)
 
 ### Examples
@@ -22,6 +24,7 @@ The most basic:
 custom:
   logSubscription:
     destinationArn: 'some-arn'
+    roleArn: 'some-arn'
 
 functions:
   myFunction:
@@ -48,6 +51,7 @@ custom:
   logSubscription:
     enabled: true
     destinationArn: 'some-arn'
+    roleArn: 'some-arn'
 
 functions:
   myFunction:

--- a/serverless-plugin-log-subscription.js
+++ b/serverless-plugin-log-subscription.js
@@ -37,6 +37,9 @@ module.exports = class LogSubscriptionsPlugin {
               LogGroupName: config.logGroupName
             }
           };
+          if(config.roleArn !== undefined) {
+            template.Resources[key][Properties][RoleArn] = config.roleArn;
+          }
         }
       });
     }

--- a/serverless-plugin-log-subscription.js
+++ b/serverless-plugin-log-subscription.js
@@ -38,7 +38,7 @@ module.exports = class LogSubscriptionsPlugin {
             }
           };
           if(config.roleArn !== undefined) {
-            template.Resources[key][Properties][RoleArn] = config.roleArn;
+            template.Resources[key].Properties.RoleArn = config.roleArn;
           }
         }
       });


### PR DESCRIPTION
Hi I've not tested this, but seemed quite straight forward from the cloudformation docs here:
http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-logs-subscriptionfilter.html

Basically in order to forward logs to a Kinesis destinationArn you also need to have a roleArn.  This field is an optional field and not required when forwarding to a lambda or other log streams, hence the if undefined check. Hopefully this would provide that support, my JS may not be the cleanest in this regard so please feel free to add comment if you would prefer it another way?

cheers for the plugin