### PR TITLE
Add serverless 2.10.0 as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,8 @@
     "eslint": "^7.29.0",
     "nyc": "^15.1.0",
     "sinon": "^11.1.1"
+  },
+  "peerDependencies": {
+    "serverless": "^2.10.0"
   }
 }


### PR DESCRIPTION
The plugin [uses](https://github.com/dougmoscrop/serverless-plugin-log-subscription/blob/9c9a1d066e5f5ab26942b964d441e65dd8cdff28/serverless-plugin-log-subscription.js#L12) the `defineFunctionProperties` method, which was not added until serverless version [2.10.0](https://github.com/serverless/serverless/blob/master/CHANGELOG.md#2100-2020-11-03)

Resolves issues https://github.com/dougmoscrop/serverless-plugin-log-subscription/issues/31 and https://github.com/dougmoscrop/serverless-plugin-log-subscription/issues/32

Installation with npm 6 will generate warnings about missing/incompatible peer dependencies. Beginning with npm 7 (node 15+), peer dependencies will be installed automatically.