### PR TITLE
Mark plugin as Serverless Framework v3 ready

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "sinon": "^11.1.1"
   },
   "peerDependencies": {
-    "serverless": "^2.10.0"
+    "serverless": "^2.10.0 || 3"
   }
 }


### PR DESCRIPTION
Plugin is confirmed to work with v3 release without issues, therefore it'll be good to whitelist v3 of the Framework in peer dependencies section