### PR TITLE
Remove optional chaining for backward compatibility with Node 12

### DIFF
--- a/serverless-plugin-log-subscription.js
+++ b/serverless-plugin-log-subscription.js
@@ -296,6 +296,6 @@ module.exports = class LogSubscriptionsPlugin {
       }
       throw err;
     }
-    return res?.Stacks.length > 0;
+    return res.Stacks.length > 0;
   }
 };


### PR DESCRIPTION
As per https://github.com/dougmoscrop/serverless-plugin-log-subscription/issues/39

PR https://github.com/dougmoscrop/serverless-plugin-log-subscription/pull/36 introduced an `isDeployed` function which made use of optional chaining, which is only available in node 14 onwards.

Have removed the use of it as it is not strictly needed, and this should fix deployments using node 12.

```
$ node -v
v12.22.8
$ npm test

> serverless-plugin-log-subscription@2.1.1 test /Users/esmith/code/github/serverless-plugins/serverless-plugin-log-subscription
> nyc ava

Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db

Why you should do it regularly:
https://github.com/browserslist/browserslist#browsers-data-updating

  27 tests passed

=============================== Coverage summary ===============================
Statements   : 85.98% ( 92/107 )
Branches     : 83.78% ( 62/74 )
Functions    : 100% ( 11/11 )
Lines        : 85.98% ( 92/107 )
================================================================================
```