### PR TITLE
Fix configuration warning

### DIFF
--- a/serverless-plugin-log-subscription.js
+++ b/serverless-plugin-log-subscription.js
@@ -8,7 +8,7 @@ module.exports = class LogSubscriptionsPlugin {
       'aws:package:finalize:mergeCustomProviderResources': () => this.addLogSubscriptions(),
     };
 
-    serverless.configSchemaHandler.defineFunctionProperties(this.provider, {
+    serverless.configSchemaHandler.defineFunctionProperties('aws', {
       properties: {
         logSubscription: { type: 'boolean' },
       },


### PR DESCRIPTION
As mentioned in the [defineFunctionProperties docs](https://www.serverless.com/framework/docs/guides/plugins/custom-configuration#function-properties-via-definefunctionproperties) the first parameter should be the `providerName` and not the provider instance.

This fix removes the configuration warning.