### PR TITLE
Updated arn to Arn

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ custom:
     enabled: true
     destinationArn:
       # Note that you have to use Serverless' naming convention here
-      Fn::GetAtt: ['LogsProcessorLambdaFunction', 'arn']
+      Fn::GetAtt: ['LogsProcessorLambdaFunction', 'Arn']
     addLambdaPermission: true # this is the default, set to false to manage your own permissions
 
 functions:


### PR DESCRIPTION
This is a silly PR but when I was copy/pasting the example in the README I ran into an error because the `a` in `Arn` was not capitalized 😄