### PR TITLE
allow FilterName to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Configuration happens both 'globally' (via custom.logSubscription) and also at t
 
 `filterPattern` (optional) if specified, it will only forward logs matching this pattern. You can do simple token matching, or JSON matching (e.g. `{ $.level >= 30 }` to match a bunyan level)
 
+`filterName` (optional) if specified, this name will be used for the FilterName property of the AWS Subscription Filter.
+
 `apiGatewayLogs` (optional) if `true` the plugin will configure a subscription filter for the API Gateway access and execution log groups. This feature only works if logging is enabled for the API gateway as well.
 
 ### Examples
@@ -47,6 +49,7 @@ Custom function settings:
 custom:
   logSubscription:
     destinationArn: 'some-arn'
+    filterName: 'some-filter-name'
 
 functions:
   myFunction:

--- a/__tests__/add-log-subscriptions.js
+++ b/__tests__/add-log-subscriptions.js
@@ -109,6 +109,7 @@ test('configures the subscription filter correctly', t => {
     enabled: true,
     destinationArn: 'blah-blah-blah',
     filterPattern: '{ $.level = 42 }',
+    filterName: 'a-custom-filter-name'
   });
 
   sinon.stub(plugin, 'getLogGroupName').returns('/aws/lambda/a');
@@ -121,6 +122,7 @@ test('configures the subscription filter correctly', t => {
     DestinationArn: 'blah-blah-blah',
     FilterPattern: '{ $.level = 42 }',
     LogGroupName: '/aws/lambda/a',
+    FilterName: 'a-custom-filter-name',
   });
 });
 
@@ -460,6 +462,7 @@ test("doesn't configure api gateway log subscriptions when provider.logs.restApi
     enabled: true,
     destinationArn: 'blah-blah-blah',
     filterPattern: '{ $.level = 42 }',
+    filterName: 'a-custom-filter-name',
     apiGatewayLogs: true,
     addLambdaPermission: true,
   });
@@ -485,6 +488,7 @@ test("doesn't configure api gateway log subscriptions when provider.logs.restApi
         DestinationArn: 'blah-blah-blah',
         FilterPattern: '{ $.level = 42 }',
         LogGroupName: '/aws/lambda/a',
+        FilterName: 'a-custom-filter-name',
       },
       DependsOn: ['ALogGroup'],
     },
@@ -494,6 +498,7 @@ test("doesn't configure api gateway log subscriptions when provider.logs.restApi
         DestinationArn: 'blah-blah-blah',
         FilterPattern: '{ $.level = 42 }',
         LogGroupName: '/aws/lambda/b',
+        FilterName: 'a-custom-filter-name',
       },
       DependsOn: ['BLogGroup'],
     },

--- a/serverless-plugin-log-subscription.js
+++ b/serverless-plugin-log-subscription.js
@@ -50,7 +50,7 @@ module.exports = class LogSubscriptionsPlugin {
           throw new Error('addSourceLambdaPermission is no longer supported, see README');
         }
 
-        const { destinationArn, filterPattern } = config;
+        const { destinationArn, filterPattern,  filterName } = config;
         const dependsOn = this.getDependsOn(destinationArn);
         const dependencies = [].concat(dependsOn || []);
 
@@ -89,6 +89,7 @@ module.exports = class LogSubscriptionsPlugin {
             DestinationArn: destinationArn,
             FilterPattern: filterPattern,
             LogGroupName: logGroupName,
+            ...filterName && {FilterName: filterName},
           },
           DependsOn: dependencies,
         };
@@ -112,7 +113,7 @@ module.exports = class LogSubscriptionsPlugin {
     template.Resources = template.Resources || {};
 
     if (config.enabled && service.provider.logs?.restApi && config.apiGatewayLogs && this.provider.naming.getApiGatewayLogGroupLogicalId) {
-      const { destinationArn, filterPattern } = config;
+      const { destinationArn, filterPattern, filterName } = config;
       const dependsOn = this.getDependsOn(destinationArn);
       const dependencies = [].concat(dependsOn || []);
       const { accessLogging = true, executionLogging = true } = service.provider.logs.restApi;
@@ -184,6 +185,7 @@ module.exports = class LogSubscriptionsPlugin {
           Properties: {
             DestinationArn: destinationArn,
             FilterPattern: filterPattern,
+            ...filterName && {FilterName: filterName},
             LogGroupName: {
               Ref: aws.naming.getApiGatewayLogGroupLogicalId(),
             },
@@ -200,6 +202,7 @@ module.exports = class LogSubscriptionsPlugin {
           Properties: {
             DestinationArn: destinationArn,
             FilterPattern: filterPattern,
+            ...filterName && {FilterName: filterName},
             LogGroupName: {
               'Fn::Sub': `API-Gateway-Execution-Logs_$\{${aws.naming.getRestApiLogicalId()}}/${
                 this.serverless.service.provider.stage


### PR DESCRIPTION
Add the ability to choose a specific filter name when creating the log subscription filter. This is needed for my use case, where the lambda that receieves cloudwatch logs uses the filter name to select an appropriate destination during processing.