### PR TITLE
fix serverless deployment warning

### DIFF
--- a/serverless-plugin-log-subscription.js
+++ b/serverless-plugin-log-subscription.js
@@ -10,7 +10,19 @@ module.exports = class LogSubscriptionsPlugin {
 
     serverless.configSchemaHandler.defineFunctionProperties('aws', {
       properties: {
-        logSubscription: { type: 'boolean' },
+        logSubscription: { anyOf: [
+          { type: 'boolean' },
+          { type: 'object',
+            properties: {
+              logGroupName: { type: 'string'},
+              enabled: { type: 'boolean'},
+              destinationArn: { type: 'string' },
+              addLambdaPermission: { type: 'boolean' },
+              filterName: { type: 'string' },
+              filterPattern: { type: 'string' }
+            }
+          }
+        ] },
       },
     });
   }


### PR DESCRIPTION
Running a serverless deployment from the command line generates warning like these when anything other than a boolean is used for the configuration of a Lambda function.
```
  origination:
    handler: origination.handler
    logSubscription:
      logGroupName: /aws/lambda/etcetc
```

```
Warning: Invalid configuration encountered
  at 'functions.origination.logSubscription': must be boolean
```
This updates the custom validation, allowing this and other valid options to be recognized by serverless. There may be other options, but these were the ones that I found - happy to add others if needed