### PR TITLE
feat: Use role arn on API Gateway log subscriptions

### DIFF
--- a/serverless-plugin-log-subscription.js
+++ b/serverless-plugin-log-subscription.js
@@ -185,6 +185,7 @@ module.exports = class LogSubscriptionsPlugin {
               },
             },
           };
+          
           template.Resources[`ApiGatewayExecutionLogGroupLambdaPermission${suffix}`] =
             executionLogLambdaPermission;
         }
@@ -204,6 +205,11 @@ module.exports = class LogSubscriptionsPlugin {
           },
           DependsOn: template.Resources[accessLogLambdaPermResourceName] ? [accessLogLambdaPermResourceName] : [],
         };
+
+        if (config.roleArn !== undefined) {
+          accessLogsubscriptionFilter.Properties.RoleArn = config.roleArn;
+        }
+
         template.Resources[`ApiGatewayAccessLogGroupSubscriptionFilter${suffix}`] =
           accessLogsubscriptionFilter;
       }
@@ -226,6 +232,11 @@ module.exports = class LogSubscriptionsPlugin {
             aws.naming.generateApiGatewayDeploymentLogicalId(this.serverless.instanceId),
           ],
         };
+
+        if (config.roleArn !== undefined) {
+          executionLogsubscriptionFilter.Properties.RoleArn = config.roleArn;
+        }
+
         template.Resources[`ApiGatewayExecutionLogGroupSubscriptionFilter${suffix}`] =
           executionLogsubscriptionFilter;
       }


### PR DESCRIPTION
Addressing issue #66 where role arn is not used on API Gateway log subscriptions. This is a problem when trying to set up a log subscription with a kinesis stream since roleArn is not optional in that case 😎 